### PR TITLE
Fixed compatibility with GHC 7.10

### DIFF
--- a/Cloud/AWS/Lib/ToText/Class.hs
+++ b/Cloud/AWS/Lib/ToText/Class.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Time (UTCTime)
 import qualified Data.Time as Time
-import System.Locale (defaultTimeLocale)
+import Data.Time.Locale.Compat (defaultTimeLocale)
 
 class ToText a where
     toText :: a -> Text

--- a/aws-sdk-text-converter.cabal
+++ b/aws-sdk-text-converter.cabal
@@ -25,7 +25,7 @@ library
                      , bytestring
                      , text
                      , time
-                     , old-locale
+                     , time-locale-compat
                      , strptime
                      , safe
                      , iproute
@@ -43,7 +43,7 @@ test-suite spec
                      , bytestring
                      , text
                      , time
-                     , old-locale
+                     , time-locale-compat
                      , strptime
                      , safe
                      , iproute


### PR DESCRIPTION
Hi!
The changes introduced in `time-1.5` (that comes with GHC 7.10) cause compilation error in this package — the `time` now uses its own `TimeLocale` instead of the one from `old-locale`. This pull request fixes it by using `time-locale-compat` package, as recommended by https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10#time-1.5.0.1

Tested with GHC 7.10.2 and GHC 7.8.4 — both are now able to build this package.